### PR TITLE
Add option to throw a warning or error for code `403 forbidden`

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,7 @@ module.exports = function (eleventyConfig, _options) {
   const options = { ...defaults, ...(_options ?? {}) };
   options.loggingLevel = parseInt(options.loggingLevel);
   options.cacheDuration = options.cacheDuration.toLowerCase();
+  options.forbidden = options.forbidden.toLowerCase();
   options.broken = options.broken.toLowerCase();
   options.redirect = options.redirect.toLowerCase();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.0 (04/04/2024)
+
+- Added option to check for forbidden links
+
+---
+
 ## 2.0.3 (05/28/2022)
 
 - fixed a bug that threw an error with empty or missing `href`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # eleventy-plugin-broken-links
 
-[![npm](https://img.shields.io/npm/v/eleventy-plugin-broken-links?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-broken-links)
-![License: MIT](https://img.shields.io/github/license/bradleyburgess/eleventy-plugin-broken-links?color=yellow&style=for-the-badge)
-![Codecov](https://img.shields.io/codecov/c/github/bradleyburgess/eleventy-plugin-broken-links?style=for-the-badge)
+### This is a fork of https://github.com/bradleyburgess/eleventy-plugin-broken-links with added support for forbidden links 
+
+[![npm](https://img.shields.io/npm/v/eleventy-plugin-broken-links?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-broken-forbiden-links)
+![License: MIT](https://img.shields.io/github/license/akashic101/eleventy-plugin-broken-links?color=yellow&style=for-the-badge)
+![Codecov](https://img.shields.io/codecov/c/github/akashic101/eleventy-plugin-broken-links?style=for-the-badge)
 
 ## Table of contents
 
@@ -237,7 +239,7 @@ Globbing is handled by `minimatch` under the hood. Some examples:
 Custom callback for handling broken, redirect or forbidden links after checking and
 logging results (and before throwing an error, if option is set). The three
 arguments, `brokenLinks`, `redirectLinks` and `forbiddenLinks` are arrays of instances of the
-[`ExternalLink` class](https://github.com/bradleyburgess/eleventy-plugin-broken-links/blob/main/lib/ExternalLink.js),
+[`ExternalLink` class](https://github.com/akashic101/eleventy-plugin-broken-links/blob/main/lib/ExternalLink.js),
 which has the following methods and properties:
 
 - `url` property
@@ -272,7 +274,7 @@ module.exports = (eleventyConfig) => {
 I don't have a specific roadmap or timeline for this project, but here is a
 general idea of what the next steps are. If you would like to contribute,
 please feel free to
-[file an issue or feature request](https://github.com/bradleyburgess/eleventy-plugin-broken-links/issues),
+[file an issue or feature request](https://github.com/akashic101/eleventy-plugin-broken-links/issues),
 or send a PR.
 
 - [x] cache results (added in `v1.1.0`)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - [3. Add `.cache` to `.gitignore`](#3-add-cache-to-gitignore)
   - [(4. Set options)](#4-set-options)
 - [Options](#options)
-  - [`broken` and `redirect`](#broken-and-redirect)
+  - [`broken`, `redirect` and `forbidden`](#broken-redirect-and-forbidden)
   - [`cacheDuration`](#cacheduration)
   - [`loggingLevel`](#logginglevel)
   - [`excludeUrls`](#excludeurls)
@@ -38,7 +38,7 @@ added at some point.
 - caching using `eleventy-fetch`
 - excluding URLs
 - control of level of logging
-- warn or error on broken or redirected links
+- warn or error on broken, redirected or forbidden links
 - exclude certain URLs or wildcards
 - exclude certain input files or globs
 
@@ -99,7 +99,8 @@ with `eleventyConfig.addPlugin()`:
 
 | Option                             | Default                                           | Accepted values                                                                                              | Description                          |
 | ---------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
-| [`broken`](#broken-and-redirect)   | `"warn"`                                          | `"warn"`, `"error"`                                                                                          | Whether to warn or throw an error    |
+| [`forbidden`](#broken-redirect-and-forbidden)| `"warn"`                                          | `"warn"`, `"error"`                                                                                          | Whether to warn or throw an error    |
+| [`broken`](#broken-and-redirect)   | `"warn"`                                          | `"warn"`, `"error"`                                                                                          | (same as above)                      |
 | [`redirect`](#broken-and-redirect) | `"warn"`                                          | `"warn"`, `"error"`                                                                                          | (same as above)                      |
 | [`cacheDuration`](#cacheduration)  | `"1d"`                                            | [any value accepted](https://www.11ty.dev/docs/plugins/fetch/#change-the-cache-duration) by `eleventy-fetch` | Set the duration of the cache        |
 | [`loggingLevel`](#logginglevel)    | `2`                                               | Integer `0` (silent) to `3` (all)                                                                            | Set the logging level                |
@@ -115,6 +116,7 @@ const brokenLinksPlugin = require("eleventy-plugin-broken-links");
 module.exports = (eleventyConfig) => {
   // ... the rest of your config
   eleventyConfig.addPlugin(brokenLinksPlugin, {
+    forbidden: "warn",
     redirect: "warn",
     broken: "warn",
     cacheDuration: "1d",
@@ -126,19 +128,19 @@ module.exports = (eleventyConfig) => {
 };
 ```
 
-NOTE: If either the `broken` or `redirect` options are set to `error`, your
+NOTE: If the `broken`, `redirect` or `forbidden` options are set to `error`, your
 build will not be successful if there are broken/redirected links!
 
 ---
 
 ## Options
 
-### `broken` and `redirect`
+### `broken`, `redirect` and `forbidden`
 
 - **Default: `"warn"`**
 - Accepted: `"warn"` or `"error"`
 
-Whether to `warn` or `error` if broken or redirect links are found. If `error`,
+Whether to `warn` or `error` if broken, redirect or forbidden links are found. If `error`,
 builds will not succeed if any are found.
 
 ### `cacheDuration`
@@ -230,11 +232,11 @@ Globbing is handled by `minimatch` under the hood. Some examples:
 ### `callback`
 
 - **Default: `null`**
-- Accepted: `null` or a function with signature `(brokenLinks, redirectLink) => {}`
+- Accepted: `null` or a function with signature `(brokenLinks, redirectLinks, forbiddenLinks) => {}`
 
-Custom callback for handling broken and redirect links after checking and
-logging results (and before throwing an error, if option is set). The two
-arguments, `brokenLinks` and `redirectLinks` are arrays of instances of the
+Custom callback for handling broken, redirect or forbidden links after checking and
+logging results (and before throwing an error, if option is set). The three
+arguments, `brokenLinks`, `redirectLinks` and `forbiddenLinks` are arrays of instances of the
 [`ExternalLink` class](https://github.com/bradleyburgess/eleventy-plugin-broken-links/blob/main/lib/ExternalLink.js),
 which has the following methods and properties:
 

--- a/__tests__/checkLinkStatuses.test.js
+++ b/__tests__/checkLinkStatuses.test.js
@@ -5,7 +5,8 @@ const checkLinkStatuses = require("../lib/checkLinkStatuses");
 const linksToCheck = [
   "https://example.com",
   "https://google.com",
-  "https://example.com/brokenlink",
+  "https://www.ft.com/404",
+  "https://www.raspberrypi.com/software/",
 ];
 
 const store = linksToCheck.map((link) => new ExternalLink(link));
@@ -14,6 +15,7 @@ test("all links have statuses", async (t) => {
   await checkLinkStatuses(store, "1d");
   t.true(store.every((item) => item.getHttpStatusCode() !== null));
   t.true(store.some((link) => link.getHttpStatusCode() == 301));
+  t.true(store.some((link) => link.getHttpStatusCode() == 403));
   t.true(store.some((link) => link.getHttpStatusCode() == 404));
   t.true(store.some((link) => link.getHttpStatusCode() == 200));
 });

--- a/__tests__/checkLinksAndOutputResults.test.js
+++ b/__tests__/checkLinksAndOutputResults.test.js
@@ -15,6 +15,7 @@ const pages = [
         <li><a href="https://example.com">Example.com</a></li>
         <li><a href="https://google.com">Google.com</a></li>
         <li><a href="https://example.com/broken">Broken Link #1</a></li>
+        <li><a href="https://www.raspberrypi.com/software/">Forbidden Link #1</a></li>
     </ul>
 </body>
 </html>`,
@@ -29,6 +30,7 @@ const pages = [
         <li><a href="https://example.com">Example.com</a></li>
         <li><a href="https://yahoo.com">Yahoo.com</a></li>
         <li><a href="https://example.com/broken2">Broken Link #1</a></li>
+        <li><a href="https://www.raspberrypi.com/software/">Forbidden Link #1</a></li>
     </ul>
 </body>
 </html>`,
@@ -49,12 +51,13 @@ test("everything works", async (t) => {
   // check store
   t.true(store.length > 0);
   t.true(store.every((item) => item instanceof ExternalLink));
-  t.is(store.length, 5);
+  t.is(store.length, 6);
   t.is(store.find((item) => item.url === "https://example.com").getLinkCount(), 2);
 
   // check results
   await checkLinksAndOutputResults(store, options)();
   t.true(s.calls.length > 0);
+  t.true(s.calls.some((call) => call.arguments[0].includes("Link forbidden")));
   t.true(s.calls.some((call) => call.arguments[0].includes("Link redirects")));
   t.true(s.calls.some((call) => call.arguments[0].includes("Link is broken")));
 });

--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -1,5 +1,6 @@
 const test = require("ava");
 const {
+  isForbidden,
   isBroken,
   isNumber,
   isFunction,
@@ -42,6 +43,15 @@ test("isNullOrUndefined", (t) => {
   t.true(isNullOrUndefined(undefined));
   t.true(isNullOrUndefined(obj.hello));
   t.false(isNullOrUndefined(obj.key));
+});
+
+test("isForbidden", (t) => {
+  const codes = [403];
+  codes.forEach((code) => {
+    t.true(isForbidden(code));
+  });
+
+  t.false(isForbidden(200));
 });
 
 test("isBroken", (t) => {

--- a/__tests__/validateUserOptions.test.js
+++ b/__tests__/validateUserOptions.test.js
@@ -3,6 +3,14 @@ const test = require("ava");
 
 const testFunc = (opts) => () => validateUserOptions(opts);
 
+test("forbidden", (t) => {
+  t.notThrows(testFunc({ forbidden: "warn" }));
+  t.notThrows(testFunc({ forbidden: "error" }));
+  t.throws(testFunc({ forbidden: 1 }));
+  t.throws(testFunc({ forbidden: "" }));
+  t.throws(testFunc({ forbidden: [] }));
+});
+
 test("broken", (t) => {
   t.notThrows(testFunc({ broken: "warn" }));
   t.notThrows(testFunc({ broken: "error" }));

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 const defaults = {
   broken: "warn",
   redirect: "warn",
+  forbidden: "warn",
   cacheDuration: "1d",
   loggingLevel: 2,
   excludeUrls: ["http://localhost*", "https://localhost*"],

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,18 +8,24 @@ const isFunction = (input) => typeof input === "function";
 
 const isNullOrUndefined = (input) => input === undefined || input === null;
 
+// forbidden = status 403
+const isForbidden = (code) => {
+  const codeNumber = parseInt(code);
+  return codeNumber == 403;
+};
+
 // broken = any status 400-504
 const isBroken = (code) => {
   if (!isNumber(code)) return true;
   const codeNumber = parseInt(code);
-  return codeNumber >= 400 && codeNumber <= 504;
+  return codeNumber >= 400 && codeNumber <= 504 && codeNumber != 403;
 };
 
 // redirect is any 3xx status
 const isRedirect = (code) => code >= 300 && code < 400;
 
 // okay is not broken or redirect
-const isOkay = (code) => !isBroken(code) && !isRedirect(code);
+const isOkay = (code) => !isForbidden(code) && !isBroken(code) && !isRedirect(code);
 
 const isWarnOrError = (input) =>
   !isString(input) ? false : input.toLowerCase() === "warn" || input.toLowerCase() === "error";
@@ -59,6 +65,7 @@ const shouldExcludePage = (inputPath, dirInput, excludeInputs) => {
 };
 
 module.exports = {
+  isForbidden,
   isBroken,
   isOkay,
   isRedirect,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,6 +24,11 @@ class Message {
     return this;
   }
 
+  forbidden() {
+    this.write = chalk.yellow;
+    return this;
+  }
+
   warn() {
     this.write = chalk.yellow;
     return this;

--- a/lib/outputResults.js
+++ b/lib/outputResults.js
@@ -1,9 +1,10 @@
 const debug = require("debug")("Eleventy:plugin-broken-links");
-const { isBroken, isRedirect, isOkay } = require("./helpers");
+const { isForbidden, isBroken, isRedirect, isOkay } = require("./helpers");
 const log = require("./logger");
 
 function outputResults(store, options) {
   // group links by status
+  const forbiddenLinks = store.filter((item) => isForbidden(item.getHttpStatusCode()));
   const brokenLinks = store.filter((item) => isBroken(item.getHttpStatusCode()));
   const redirectLinks = store.filter((item) => isRedirect(item.getHttpStatusCode()));
   const okayLinks = store.filter((item) => isOkay(item.getHttpStatusCode()));
@@ -12,6 +13,16 @@ function outputResults(store, options) {
   options.loggingLevel === 3 &&
     okayLinks.forEach((link) => {
       log().okay().display(`Link okay:      ${link.url}`);
+    });
+
+  // log forbidden
+  options.loggingLevel >= 2 &&
+    forbiddenLinks.forEach((link) => {
+      const pages = link.getPages();
+      log().warn().display(`Link forbidden: ${link.url}`);
+      log().display(`HTTP Status Code: ${link.getHttpStatusCode()}`);
+      log().display(`Used ${link.getLinkCount()} time(s) on these pages:`, 2);
+      pages.forEach((page) => log().bullet().indent().display(page));
     });
 
   // log redirects
@@ -43,10 +54,13 @@ function outputResults(store, options) {
     options.callback(brokenLinks, redirectLinks);
   }
 
+  if (forbiddenLinks.length > 0) debug(`found ${forbiddenLinks.length} broken links`);
   if (brokenLinks.length > 0) debug(`found ${brokenLinks.length} broken links`);
   if (redirectLinks.length > 0) debug(`found ${redirectLinks.length} redirect links`);
 
   // check to see if we need to throw an error
+  if (options.broken === "error" && forbiddenLinks.length > 0)
+    throw new Error("There are forbidden links in your build! See above for details.");
   if (options.broken === "error" && brokenLinks.length > 0)
     throw new Error("There are broken links in your build! See above for details.");
   if (options.redirect === "error" && redirectLinks.length > 0)

--- a/lib/validateUserOptions.js
+++ b/lib/validateUserOptions.js
@@ -14,6 +14,10 @@ function validateUserOptions(opts) {
 
   if (!opts) return;
 
+  if ("forbidden" in opts) {
+    if (!isWarnOrError(opts.forbidden))
+      throw new Error(error("forbidden", "must be `warn` or `error`"));
+  }
   if ("broken" in opts) {
     if (!isWarnOrError(opts.broken)) throw new Error(error("broken", "must be `warn` or `error`"));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8111,8 +8111,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -9442,8 +9441,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "4.0.0",
@@ -11022,8 +11020,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ninos/-/ninos-3.0.0.tgz",
       "integrity": "sha512-y0PICjHqj7BCA04ayG0neJChSWt0oUKLtnDQZJu6ey+wtlpddQA1JwH0JtB6u+Q/Twkuz+pUIAZeZMHxUqgr4A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -12956,8 +12953,7 @@
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-broken-forbiden-links",
-  "version": "1.0.1",
+  "version": "2.1.0",
   "description": "An Eleventy plugin to check for broken external links with extended support for forbidden links",
   "homepage": "https://github.com/Akashic101/eleventy-plugin-broken-links",
   "main": ".eleventy.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "eleventy-plugin-broken-links",
-  "version": "2.0.3",
-  "description": "An Eleventy plugin to check for broken external links",
-  "homepage": "https://github.com/bradleyburgess/eleventy-plugin-broken-links",
+  "name": "eleventy-plugin-broken-forbiden-links",
+  "version": "1.0.0",
+  "description": "An Eleventy plugin to check for broken external links with extended support for forbidden links",
+  "homepage": "https://github.com/Akashic101/eleventy-plugin-broken-links",
   "main": ".eleventy.js",
   "scripts": {
     "start": "eleventy --serve",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bradleyburgess/eleventy-plugin-broken-links.git"
+    "url": "git+https://github.com/Akashic101/eleventy-plugin-broken-links"
   },
   "keywords": [
     "11ty",
@@ -24,13 +24,10 @@
     "eleventy-plugin",
     "broken-links"
   ],
-  "author": {
-    "name": "Bradley Burgess",
-    "url": "https://github.com/bradleyburgess"
-  },
+  "author": "David Moll (https://github.com/Akashic101)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/bradleyburgess/eleventy-plugin-broken-links/issues"
+    "url": "https://github.com/Akashic101/eleventy-plugin-broken-links/issues"
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",
@@ -56,5 +53,8 @@
       "__tests__/**/*.js",
       "**/*.test.js"
     ]
+  },
+  "directories": {
+    "lib": "lib"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-broken-forbiden-links",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An Eleventy plugin to check for broken external links with extended support for forbidden links",
   "homepage": "https://github.com/Akashic101/eleventy-plugin-broken-links",
   "main": ".eleventy.js",


### PR DESCRIPTION
Right now the plugin throws an error when a website returns `code 403 forbidden`. This can be not-intended behaviour, one example (which is also used for tests) is https://www.raspberrypi.com/software/ which works fine when being visited via a browser but not with this plugin. Another link is mentioned in issue #9 

This PR fixes this by adding another option next to broken and redirect link available in the options. Now the user can decide how to handle forbidden links on their own. This of course could be extended to other codes as well but for now 403 is the only one making problems.