### PR TITLE
Fix failing jest (timeout)

### DIFF
--- a/__tests__/checkLinksAndOutputResults.test.js
+++ b/__tests__/checkLinksAndOutputResults.test.js
@@ -3,6 +3,9 @@ const ExternalLink = require("../lib/ExternalLink");
 const getExternalLinksFromPage = require("../lib/getExternalLinksFromPage");
 const { defaults } = require("../lib/constants");
 
+const SECONDS = 1000;
+jest.setTimeout(10 * SECONDS);
+
 const pages = [
   {
     inputPath: "./src/index.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-broken-links",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "An Eleventy plugin to check for broken external links",
   "homepage": "https://github.com/bradleyburgess/eleventy-plugin-broken-links",
   "main": ".eleventy.js",


### PR DESCRIPTION
Bump the timeout for `checkLinksAndOutResults.test.js` to 10 seconds.